### PR TITLE
feat issue #31: 마일스톤 및 스프린트 일정 캘린더 연동 기능 구현

### DIFF
--- a/templates/calendar_back.html
+++ b/templates/calendar_back.html
@@ -61,8 +61,9 @@
         </ul>
     </div>
 
-    <!-- 일정 추가 버튼 -->
     <a href="{{ url_for('calendar.create_schedule_view', project_id=project_id) }}">일정 추가하기</a>
+
+    <a href="{{ url_for('project_main.project_main_view', project_id=project_id) }}" style="display: block;">프로젝트 메인으로 돌아가기</a>
 </div>
 
 </body>

--- a/templates/schedule_detail_back.html
+++ b/templates/schedule_detail_back.html
@@ -65,6 +65,9 @@
             <form action="{{ url_for('calendar.delete_schedule_view', project_id=project.project_id, calendar_id=schedule.calendar_id) }}" method="POST">
                 <button type="submit" class="cancel-button">일정 삭제</button>
             </form>
+            <form action="{{ url_for('calendar.calendar_view', project_id=project.project_id) }}" method="GET">
+                <button type="submit" class="back-button">취소</button>
+            </form>
         </div>
     </form>
 </div>

--- a/templates/topbar.html
+++ b/templates/topbar.html
@@ -6,7 +6,7 @@
             </a>
         </li>
         <li>
-            <a href="{{ url_for('calendar') }}">
+            <a href="{{ url_for('calendar.calendar_view', project_id=project.project_id) }}">
                 <img src="{{ url_for('static', filename='icons/calendar.svg') }}" alt="캘린더 아이콘"> 캘린더
             </a>
         </li>

--- a/views/milestone_view.py
+++ b/views/milestone_view.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash
 from controllers.milestone_controller import get_milestones, create_milestone, update_milestone, delete_milestone, get_milestone_counts
+from controllers.calendar_controller import create_schedule
 from models.project_model import UserProject, Project
-from models.milestone_model import Milestone
 from flask_login import login_required, current_user
 
 # Blueprint 객체 생성
@@ -23,11 +23,12 @@ def milestone_view(project_id):
 @milestone_bp.route('/<int:project_id>/create', methods=['POST'])
 @login_required
 def create_milestone_view(project_id):
-        milestone_content = request.form.get('milestone_content')
-        due_date = request.form.get('due_date')
-        message = create_milestone(project_id, milestone_content, due_date)
-        flash(message)
-        return redirect(url_for('milestone.milestone_view', project_id=project_id))
+    milestone_content = request.form.get('milestone_content')
+    due_date = request.form.get('due_date')
+    create_milestone(project_id, milestone_content, due_date)
+    create_schedule(project_id, milestone_content, None, due_date, due_date, True, 0, None, True)
+
+    return redirect(url_for('milestone.milestone_view', project_id=project_id))
 
 # # 마일스톤 수정 로직
 # @milestone_bp.route('/<int:project_id>/<int:milestone_id>/update', methods=['GET', 'POST'])

--- a/views/sprint_view.py
+++ b/views/sprint_view.py
@@ -4,6 +4,7 @@ from controllers.sprint_controller import (
     assign_backlogs_to_sprint, create_sprint, delete_backlog, get_sprints_with_backlogs, get_unassigned_product_backlogs, get_users_by_project_id, update_backlog_details, update_backlog_status, update_sprint, delete_sprint,
     get_all_product_backlogs, create_sprint_backlog
 )
+from controllers.calendar_controller import create_schedule
 from models.project_model import Project, UserProject
 from flask_login import current_user, login_required
 
@@ -28,7 +29,6 @@ def get_product_backlogs_view(project_id):
                            backlogs=backlogs, sprints=sprints, users=users, project_id=project_id)
 
 # 스프린트 추가
-# 스프린트 추가
 @sprint_bp.route('/add-sprint', methods=['POST'])
 def add_sprint():
     project_id = request.form['project_id']
@@ -39,6 +39,7 @@ def add_sprint():
     selected_backlogs = request.form.getlist('backlogs')
 
     new_sprint, error = create_sprint(project_id, sprint_name, start_date, end_date, status)
+    create_schedule(project_id, sprint_name, None, start_date, end_date, True, 0, None, True)
     if new_sprint:
         assign_backlogs_to_sprint(new_sprint.sprint_id, selected_backlogs)
         return redirect(url_for('sprint.get_product_backlogs_view', project_id=project_id, status=1))


### PR DESCRIPTION
## #️⃣연관된 이슈

> #31

## 📝작업 내용

> 마일스톤/스프린트 생성 시 캘린더에 팀 일정으로 추가하는 기능을 구현함

### 스크린샷

![image](https://github.com/user-attachments/assets/c1502613-bab0-4195-b230-70261780a234)

## 💬리뷰 요구사항
> 마일스톤과 스프린트 일정은 다른 색으로 구분하는지, 한다면 어떤 색으로 할 지를 정해야 할 것 같아요