### PR TITLE
feat issue #94: 스크럼보드 프론트엔드 구현

### DIFF
--- a/static/js/scrum.js
+++ b/static/js/scrum.js
@@ -1,6 +1,7 @@
 // 드래그가 가능한 항목을 끌 때 발생하는 이벤트
 function drag(ev) {
   ev.dataTransfer.setData("text", ev.target.id); // 드래그된 요소의 ID를 저장
+  ev.dataTransfer.setDragImage(ev.target, 0, 0); // 원본 요소를 그대로 표시
 }
 
 // 드롭이 가능한 구역에 드래그된 항목이 올 때 발생하는 이벤트
@@ -26,39 +27,60 @@ function drop(ev) {
   }
 }
 
-// 각 scrum-sprint-item 요소에 드래그, 드롭 이벤트 핸들러 추가
+// 각 scrum-sprint-item 요소에 드래그 이벤트 핸들러 추가
 document.querySelectorAll(".scrum-sprint-item").forEach((item) => {
-  item.addEventListener("dragstart", function (event) {
-    drag(event); // 드래그 시작 시
-  });
+  item.addEventListener("dragstart", drag); // 드래그 시작 시
 });
 
-// 각 scrum-content 영역에 allowDrop 이벤트 핸들러 추가
+// 각 scrum-content 영역에 드롭 이벤트 핸들러 추가
 document.querySelectorAll(".scrum-content").forEach((content) => {
-  content.addEventListener("dragover", function (event) {
-    allowDrop(event); // 드래그오버 시
-  });
-  content.addEventListener("drop", function (event) {
-    drop(event); // 드롭 시
-  });
+  content.addEventListener("dragover", allowDrop); // 드래그 오버 시
+  content.addEventListener("drop", drop); // 드롭 시
 });
 
-// 드롭다운 토글 함수
-function toggleSprintDropdown() {
-  var dropdown = document.getElementById("sprintDropdown");
+document.addEventListener("DOMContentLoaded", () => {
+  const scrumContents = document.querySelectorAll(".scrum-content");
 
-  // 드롭다운 메뉴 토글
-  if (dropdown.style.display === "block") {
-    dropdown.style.display = "none";
-  } else {
-    dropdown.style.display = "block";
-  }
-}
+  scrumContents.forEach((scrumContent) => {
+    let draggedItem = null;
 
-// 페이지가 로드된 후 이벤트 리스너 추가
-document.addEventListener("DOMContentLoaded", function () {
-  var sprintChangeBtn = document.querySelector(".sprint-change-btn");
+    // 드래그 시작
+    scrumContent.addEventListener("dragstart", (event) => {
+      draggedItem = event.target; // 드래그 중인 요소 저장
+    });
 
-  // sprintChangeBtn 클릭 시 드롭다운 토글
-  sprintChangeBtn.addEventListener("click", toggleSprintDropdown);
+    // 드래그 종료
+    scrumContent.addEventListener("dragend", (event) => {
+      event.target.style.opacity = "1"; // 반투명 복원
+      draggedItem = null; // 드래그 요소 초기화
+    });
+
+    // 드래그 중 요소가 다른 요소 위로 올 때
+    scrumContent.addEventListener("dragover", (event) => {
+      event.preventDefault(); // 기본 동작 방지
+      const target = event.target;
+
+      // 현재 대상이 드래그 가능한 아이템인지 확인
+      if (
+        target &&
+        target !== draggedItem &&
+        target.classList.contains("scrum-sprint-item")
+      ) {
+        const bounding = target.getBoundingClientRect();
+        const offset = event.clientY - bounding.top;
+
+        // 마우스 위치에 따라 위/아래로 이동
+        if (offset > bounding.height / 2) {
+          target.parentNode.insertBefore(draggedItem, target.nextSibling); // 아래로 이동
+        } else {
+          target.parentNode.insertBefore(draggedItem, target); // 위로 이동
+        }
+      }
+    });
+
+    // 드롭 처리
+    scrumContent.addEventListener("drop", (event) => {
+      event.preventDefault(); // 기본 동작 방지
+    });
+  });
 });

--- a/static/js/scrum.js
+++ b/static/js/scrum.js
@@ -1,0 +1,64 @@
+// 드래그가 가능한 항목을 끌 때 발생하는 이벤트
+function drag(ev) {
+  ev.dataTransfer.setData("text", ev.target.id); // 드래그된 요소의 ID를 저장
+}
+
+// 드롭이 가능한 구역에 드래그된 항목이 올 때 발생하는 이벤트
+function allowDrop(ev) {
+  ev.preventDefault(); // 기본 동작을 방지하여 드롭을 허용
+}
+
+// 항목을 드롭했을 때 발생하는 이벤트
+function drop(ev) {
+  ev.preventDefault();
+  var data = ev.dataTransfer.getData("text"); // 드래그된 항목의 ID 가져오기
+  var draggedItem = document.getElementById(data); // ID로 요소를 찾기
+  var dropTarget = ev.target; // 드롭된 위치를 찾기
+
+  // 드롭된 위치가 scrum-content 영역인지 확인
+  while (dropTarget && !dropTarget.classList.contains("scrum-content")) {
+    dropTarget = dropTarget.parentNode; // 부모 요소로 이동하여 scrum-content 확인
+  }
+
+  // 드롭 대상이 scrum-content이고, 드래그된 항목이 해당 scrum-content의 자식이 아닐 경우 항목을 추가
+  if (dropTarget && dropTarget !== draggedItem.parentNode) {
+    dropTarget.appendChild(draggedItem); // 드래그된 항목을 드롭된 scrum-content에 추가
+  }
+}
+
+// 각 scrum-sprint-item 요소에 드래그, 드롭 이벤트 핸들러 추가
+document.querySelectorAll(".scrum-sprint-item").forEach((item) => {
+  item.addEventListener("dragstart", function (event) {
+    drag(event); // 드래그 시작 시
+  });
+});
+
+// 각 scrum-content 영역에 allowDrop 이벤트 핸들러 추가
+document.querySelectorAll(".scrum-content").forEach((content) => {
+  content.addEventListener("dragover", function (event) {
+    allowDrop(event); // 드래그오버 시
+  });
+  content.addEventListener("drop", function (event) {
+    drop(event); // 드롭 시
+  });
+});
+
+// 드롭다운 토글 함수
+function toggleSprintDropdown() {
+  var dropdown = document.getElementById("sprintDropdown");
+
+  // 드롭다운 메뉴 토글
+  if (dropdown.style.display === "block") {
+    dropdown.style.display = "none";
+  } else {
+    dropdown.style.display = "block";
+  }
+}
+
+// 페이지가 로드된 후 이벤트 리스너 추가
+document.addEventListener("DOMContentLoaded", function () {
+  var sprintChangeBtn = document.querySelector(".sprint-change-btn");
+
+  // sprintChangeBtn 클릭 시 드롭다운 토글
+  sprintChangeBtn.addEventListener("click", toggleSprintDropdown);
+});

--- a/static/scrum.css
+++ b/static/scrum.css
@@ -1,0 +1,145 @@
+@import url("global.css");
+
+.main-container {
+  margin-top: 2vh; /* 탑바 밑 여백 추가 */
+  margin-left: 25vh; /* 사이드바 너비만큼 왼쪽 여백 추가 */
+}
+
+.content {
+  display: flex;
+  padding: 20px;
+  flex-direction: column;
+  text-align: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.scrum-title-wrapper {
+  justify-content: space-between;
+  display: flex;
+  margin: 0px 20px;
+}
+
+.title-right {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  cursor: pointer;
+}
+
+.sprint-change-btn {
+  display: flex;
+  border: none;
+  cursor: pointer;
+  align-items: center;
+  gap: 4px;
+  position: relative;
+}
+
+.sprint-percentage-container {
+  background-color: var(--color-white);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 12px 20px;
+  width: 50%;
+  border-radius: 10px;
+  border: 1px solid var(--color-grey-100);
+}
+
+.scrum-board-container {
+  margin: 20px;
+  display: flex;
+  gap: 24px;
+  justify-content: space-between; /* Distributes space evenly */
+  align-items: flex-start; /* Aligns them to the top */
+}
+
+.todo-container,
+.inprogress-container,
+.done-container {
+  padding: 20px;
+  width: 28vw;
+  height: 70vh;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.todo-container {
+  background: #c8e4f2;
+}
+
+.inprogress-container {
+  background: #fefbd1;
+}
+
+.done-container {
+  background: #ffdada;
+}
+
+.scrum-board-title {
+  text-align: left;
+  margin-bottom: 3vh;
+}
+
+.todo-container h1 {
+  color: #7accf4;
+}
+
+.inprogress-container h1 {
+  color: #ede13a;
+}
+
+.done-container h1 {
+  color: #ff8e8e;
+}
+
+.scrum-content {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.scrum-sprint-item {
+  display: flex;
+  width: 100%;
+  padding: 16px 18px;
+  justify-content: space-between;
+  align-items: center;
+  border-radius: 10px;
+  border: 1px solid var(--color-grey-50);
+  background-color: var(--color-white);
+  margin-bottom: 8px;
+}
+
+/* 드롭다운 기본 숨김 */
+.sprint-dropdown {
+  display: none;
+  position: absolute;
+  background-color: white;
+  border: 1px solid #ddd;
+  z-index: 100;
+  margin-top: 10px;
+  padding: 5px;
+  top: 100%;
+}
+
+.sprint-dropdown ul {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sprint-dropdown ul li {
+  text-align: left;
+  padding: 8px 10px;
+  cursor: pointer;
+}
+
+.sprint-dropdown ul li:hover {
+  background-color: var(--color-grey-50);
+}

--- a/static/scrum.css
+++ b/static/scrum.css
@@ -65,7 +65,6 @@
   border-radius: 10px;
   display: flex;
   flex-direction: column;
-  overflow-y: auto;
 }
 
 .todo-container {
@@ -102,6 +101,33 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
+  overflow-y: auto;
+}
+
+/* 스크롤바 설정*/
+.scrum-content::-webkit-scrollbar {
+  background-color: transparent;
+  width: 6px;
+}
+/* 스크롤바 막대 설정*/
+.scrum-content::-webkit-scrollbar-thumb {
+  background-color: #babac0;
+  border-radius: 16px;
+}
+.scrum-content::-webkit-scrollbar-thumb:hover {
+  background-color: #a0a0a5;
+}
+
+/* 스크롤바 뒷 배경 설정*/
+.scrum-content::-webkit-scrollbar-track {
+  border-radius: 10px;
+  background-color: transparent;
+}
+.scrum-content::-webkit-scrollbar-track:hover {
+  background-color: transparent;
+}
+.scrum-content::-webkit-scrollbar-button {
+  display: none;
 }
 
 .scrum-sprint-item {
@@ -114,6 +140,10 @@
   border: 1px solid var(--color-grey-50);
   background-color: var(--color-white);
   margin-bottom: 8px;
+}
+
+.scrum-sprint-item:active {
+  cursor: grabbing;
 }
 
 /* 드롭다운 기본 숨김 */

--- a/templates/scrum.html
+++ b/templates/scrum.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>스크럼 보드</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='global.css') }}"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='scrum.css') }}"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='topbar.css') }}"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='sidebar.css') }}"
+    />
+  </head>
+  <body>
+    {% include 'topbar.html' %}
+    <div class="main-container">
+      {% include 'sidebar.html' %}
+      <div class="content">
+        <!-- 메인 콘텐츠가 들어갈 부분 -->
+        {% block content %}
+        <div class="scrum-title-wrapper">
+          <div class="title-right">
+            <h1>스크럼 보드</h1>
+            <div class="sprint-change-btn">
+              <h2>스프린트 이름</h2>
+              <img src="/static/icons/chevron-down.svg" />
+              <div class="sprint-dropdown" id="sprintDropdown">
+                <ul>
+                  <li>스프린트 1</li>
+                  <li>스프린트 2</li>
+                  <li>스프린트 3</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+
+          <div class="sprint-percentage-container">
+            <p>스프린트 작업 완료율</p>
+            <div class="sprint-bar"></div>
+          </div>
+        </div>
+
+        <div class="scrum-board-container">
+          <div class="todo-container">
+            <h1 class="scrum-board-title">To Do</h1>
+            <div
+              class="scrum-content"
+              id="todo"
+              ondrop="drop(event)"
+              ondragover="allowDrop(event)"
+            >
+              <div
+                class="scrum-sprint-item"
+                id="item-1"
+                draggable="true"
+                ondragstart="drag(event)"
+              >
+                <p>작업 이름</p>
+                <span class="user-circle"> 이름 </span>
+              </div>
+            </div>
+          </div>
+          <div class="inprogress-container">
+            <h1 class="scrum-board-title">In Progress</h1>
+            <div
+              class="scrum-content"
+              id="inprogress"
+              ondrop="drop(event)"
+              ondragover="allowDrop(event)"
+            >
+              <div
+                class="scrum-sprint-item"
+                id="item-2"
+                draggable="true"
+                ondragstart="drag(event)"
+              >
+                <p>작업 이름</p>
+                <span class="user-circle"> 이름 </span>
+              </div>
+            </div>
+          </div>
+          <div class="done-container">
+            <h1 class="scrum-board-title">Done</h1>
+            <div
+              class="scrum-content"
+              id="done"
+              ondrop="drop(event)"
+              ondragover="allowDrop(event)"
+            >
+              <div
+                class="scrum-sprint-item"
+                id="item-3"
+                draggable="true"
+                ondragstart="drag(event)"
+              >
+                <p>작업 이름</p>
+                <span class="user-circle"> 이름 </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        {% endblock %}
+      </div>
+    </div>
+
+    <!-- 외부 JavaScript 파일 연결 -->
+    <script src="{{ url_for('static', filename='js/scrum.js') }}"></script>
+  </body>
+</html>

--- a/templates/scrum.html
+++ b/templates/scrum.html
@@ -102,13 +102,23 @@
               ondragover="allowDrop(event)"
             >
               <div
-                class="scrum-sprint-item"
-                id="item-3"
-                draggable="true"
-                ondragstart="drag(event)"
+                class="scrum-content"
+                id="done"
+                ondrop="drop(event)"
+                ondragover="allowDrop(event)"
               >
-                <p>작업 이름</p>
-                <span class="user-circle"> 이름 </span>
+                {% for i in range(3, 9) %}
+                <!-- 1부터 8까지 반복 -->
+                <div
+                  class="scrum-sprint-item"
+                  id="item-{{ i }}"
+                  draggable="true"
+                  ondragstart="drag(event)"
+                >
+                  <p>작업 이름 {{ i }}</p>
+                  <span class="user-circle">사용자 {{ i }}</span>
+                </div>
+                {% endfor %}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #94 

## 📝작업 내용

> 스크럼보드 프론트엔드 기본적인 부분 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 구조가 이해가 안된다면 물어봐주세요 ..
> 스프린트 퍼센테이지 부분은 계속 에러떠서 비워놨어요
> 스프린트 아이템 칸 드래그, 스프린트 이름 드롭앤다운은 js에서 구현하고있어요