### PR TITLE
feat issue #90: 스프린트 회고 생성, 수정, 조회, 삭제

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from views.milestone_view import milestone_bp
 from views.productbacklog_view import productbacklog_bp
 from views.sprint_view import sprint_bp
 from views.calendar_view import calendar_bp
+from views.retrospect_view import retrospect_bp
 from dotenv import load_dotenv
 from database import init_db
 
@@ -37,6 +38,7 @@ app.register_blueprint(productbacklog_bp, url_prefix='/productbacklog')
 app.register_blueprint(sprint_bp, url_prefix='/sprint')
 app.register_blueprint(userstory_bp, url_prefix='/userstory')
 app.register_blueprint(calendar_bp, url_prefix='/calendar')
+app.register_blueprint(retrospect_bp, url_prefix='/retrospect')
 
 @app.route("/")
 def index():
@@ -68,9 +70,9 @@ def main():
 def board():
     return render_template("board.html")
 
-@app.route("/review")
-def review():
-    return render_template("review.html")
+# @app.route("/review")
+# def review():
+#     return render_template("review.html")
 
 # @app.route('/project')
 # def project():

--- a/controllers/retrospect_controller.py
+++ b/controllers/retrospect_controller.py
@@ -1,8 +1,7 @@
 # retrospect_controller.py
 
 from models.retrospect_model import Retrospect
-from models.user_model import Users
-from models.project_model import Project, UserProject
+from models.project_model import UserProject
 from models.sprint_model import Sprint
 from database import db
 
@@ -61,3 +60,15 @@ def delete_retrospect(retrospect_id):
     db.session.delete(retrospect)
     db.session.commit()
     return True
+
+# # 회고를 필터링하는 함수
+# def get_filtered_retrospects(project_id, category=None, sprint_id=None, page=1, per_page=12):
+#     query = Retrospect.query.filter_by(project_id=project_id)
+
+#     if category and category != 'all':
+#         query = query.filter_by(label=category)
+    
+#     if sprint_id and sprint_id != 'all':
+#         query = query.filter_by(sprint_id=sprint_id)
+
+#     return query.order_by(Retrospect.retrospect_id.desc()).paginate(page=page, per_page=per_page, error_out=False)

--- a/controllers/retrospect_controller.py
+++ b/controllers/retrospect_controller.py
@@ -1,0 +1,63 @@
+# retrospect_controller.py
+
+from models.retrospect_model import Retrospect
+from models.user_model import Users
+from models.project_model import Project, UserProject
+from models.sprint_model import Sprint
+from database import db
+
+# 특정 프로젝트의 스프린트 목록을 가져오는 함수
+def get_sprints(project_id):
+    try:
+        sprints = Sprint.query.filter_by(project_id=project_id).order_by(Sprint.sprint_id).all()
+        return sprints if sprints else []
+    except Exception:
+        return None
+
+# 회고를 생성하고 저장하는 함수
+def create_retrospect(data):
+    retrospect = Retrospect(
+        user_id=data.get('user_id'),
+        project_id=data.get('project_id'),
+        sprint_id=data.get('sprint_id'),
+        retrospect_title=data.get('retrospect_title'),
+        retrospect_content=data.get('retrospect_content'),
+        label=data.get('label')
+    )
+    db.session.add(retrospect)
+    db.session.commit()
+    return True
+
+# 회고를 수정하는 함수
+def update_retrospect(retrospect_id, data):
+    retrospect = Retrospect.query.get(retrospect_id)
+    if not retrospect:
+        return False
+    retrospect.retrospect_title = data.get("retrospect_title", retrospect.retrospect_title)
+    retrospect.retrospect_content = data.get("retrospect_content", retrospect.retrospect_content)
+    retrospect.label = data.get("label", retrospect.label)
+    db.session.commit()
+    return True
+
+# 회고를 조회하는 함수
+def get_retrospect_by_id(retrospect_id):
+    retrospect = Retrospect.query.get(retrospect_id)
+    if not retrospect:
+        return None
+    return retrospect
+
+# 특정 프로젝트의 사용자 이름을 가져오는 함수
+def get_user_name_by_project_and_user(project_id, user_id):
+    user_project = UserProject.query.filter_by(project_id=project_id, user_id=user_id).first()
+    if not user_project:
+        return "Unknown User"
+    return user_project.user_name
+
+# 회고를 삭제하는 함수
+def delete_retrospect(retrospect_id):
+    retrospect = Retrospect.query.get(retrospect_id)
+    if not retrospect:
+        return False
+    db.session.delete(retrospect)
+    db.session.commit()
+    return True

--- a/models/retrospect_model.py
+++ b/models/retrospect_model.py
@@ -1,0 +1,29 @@
+# retrospect_model.py
+from database import db
+
+class Retrospect(db.Model):
+    __tablename__ = 'Retrospect'
+
+    retrospect_id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    user_id = db.Column(db.String(255), db.ForeignKey('User.user_id', ondelete='CASCADE'), nullable=False)
+    project_id = db.Column(db.Integer, db.ForeignKey('Project.project_id', ondelete='CASCADE'), nullable=False)
+    sprint_id = db.Column(db.Integer, db.ForeignKey('Sprint.sprint_id', ondelete='CASCADE'), nullable=False)
+    retrospect_title = db.Column(db.String(50), nullable=True)
+    retrospect_content = db.Column(db.Text, nullable=True)
+    label = db.Column(db.String(10), nullable=True)
+
+    def __init__(self, user_id, project_id, sprint_id, retrospect_title=None, retrospect_content=None, label=None):
+        self.user_id = user_id
+        self.project_id = project_id
+        self.sprint_id = sprint_id
+        self.retrospect_title = retrospect_title
+        self.retrospect_content = retrospect_content
+        self.label = label
+
+    def save_to_db(self):
+        db.session.add(self)
+        db.session.commit()
+
+    def delete_from_db(self):
+        db.session.delete(self)
+        db.session.commit()

--- a/templates/create_retrospect_back.html
+++ b/templates/create_retrospect_back.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>회고 등록</title>
+</head>
+<body>
+
+    <h2>회고 작성하기</h2>
+    <!-- <form method="POST" action="{{ url_for('retrospect.create_retrospect_view', project_id=project.project_id) }}"> -->
+    <form method="POST" action="{{ retrospect and url_for('retrospect.edit_retrospect_view', project_id=project.project_id, retrospect_id=retrospect.retrospect_id) or url_for('retrospect.create_retrospect_view', project_id=project.project_id) }}">
+        <label for="title">제목:</label>
+        <input type="text" id="title" name="retrospect_title" value="{{ retrospect.retrospect_title if retrospect else '' }}" required>
+
+        <label for="sprint">스프린트:</label>
+        <select id="sprint" name="sprint_id" required>
+            {% for sprint in sprints %}
+            <option value="{{ sprint.sprint_id }}" {% if retrospect and sprint.sprint_id == retrospect.sprint_id %}selected{% endif %}>
+                {{ sprint.sprint_name }}
+            </option>
+            {% endfor %}
+        </select>
+
+        <label for="category">카테고리:</label>
+        <select id="category" name="label" required>
+            <option value="retrospect" {% if retrospect and retrospect.label == 'retrospect' %}selected{% endif %}>회고</option>
+            <option value="risk" {% if retrospect and retrospect.label == 'risk' %}selected{% endif %}>리스크</option>
+        </select>
+
+        <label for="content">내용:</label>
+        <textarea id="content" name="retrospect_content" required>{{ retrospect.retrospect_content if retrospect else '' }}</textarea>
+
+        <button type="submit">작성 완료하기</button>
+        <button type="cancel">취소</button>
+    </form>
+
+</body>
+</html>

--- a/templates/retrospect_back.html
+++ b/templates/retrospect_back.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>스프린트 회고</title>
+</head>
+<body>
+
+    <header>
+        <h2>스프린트 회고</h2>
+        <button onclick="location.href='{{ url_for('retrospect.create_retrospect_view', project_id=project.project_id) }}'">회고 등록</button>
+    </header>
+
+    <div class="filter">
+        <form method="GET" action="{{ url_for('retrospect.retrospect_view', project_id=project.project_id) }}">
+            <label for="category">카테고리:</label>
+            <select id="category" name="category">
+                <option value="all" {% if request.args.get('category') == 'all' %}selected{% endif %}>전체 보기</option>
+                <option value="retrospect" {% if request.args.get('category') == 'retrospect' %}selected{% endif %}>회고</option>
+                <option value="risk" {% if request.args.get('category') == 'risk' %}selected{% endif %}>리스크</option>
+            </select>
+
+            <label for="sprint">스프린트:</label>
+            <select id="sprint" name="sprint">
+                <option value="all" {% if request.args.get('sprint') == 'all' %}selected{% endif %}>전체 보기</option>
+                {% for sprint in sprints %}
+                    <option value="{{ sprint.sprint_id }}" {% if request.args.get('sprint') == sprint.sprint_id|string %}selected{% endif %}>{{ sprint.sprint_name }}</option>
+                {% endfor %}
+            </select>
+
+            <button type="submit">필터</button>
+        </form>
+    </div>
+
+    <table>
+        <thead>
+            <tr>
+                <th>카테고리</th>
+                <th>회고 제목</th>
+                <th>작성자</th>
+                <th>스프린트 이름</th>
+                <th>메뉴</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for retrospect in retrospects.items %}
+            <tr>
+                <td>{{ retrospect.label }}</td>
+                <td>
+                    <a href="{{ url_for('retrospect.view_retrospect_view', project_id=project.project_id, retrospect_id=retrospect.retrospect_id) }}">
+                        {{ retrospect.retrospect_title }}
+                    </a>
+                </td>
+                <td>
+                    {% if retrospect.user_id in user_map %}
+                        {{ user_map[retrospect.user_id] }}
+                    {% else %}
+                        Unknown User
+                    {% endif %}
+                </td>   
+                <td>
+                    {% for sprint in sprints %}
+                        {% if sprint.sprint_id == retrospect.sprint_id %}
+                            {{ sprint.sprint_name }}
+                        {% endif %}
+                    {% endfor %}
+                </td>
+                <td>
+                    <button onclick="location.href='{{ url_for('retrospect.get_edit_retrospect_view', project_id=project.project_id, retrospect_id=retrospect.retrospect_id) }}'">수정</button>
+                    <form method="POST" action="{{ url_for('retrospect.delete_retrospect_view', project_id=project.project_id, retrospect_id=retrospect.retrospect_id) }}" style="display:inline;">
+                        <button type="submit" onclick="return confirm('회고를 삭제하시겠습니까?')">삭제</button>
+                    </form>
+                </td>
+            </tr>
+            {% else %}
+            <tr>
+                <td colspan="5">회고가 없습니다.</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    <div class="pagination">
+        {% if retrospects.has_prev %}
+            <a href="{{ url_for('retrospect.retrospect_view', project_id=project.project_id, page=retrospects.prev_num) }}">&lt; 이전</a>
+        {% endif %}
+        {% for page_num in retrospects.iter_pages(left_edge=2, right_edge=2, left_current=1, right_current=1) %}
+            {% if page_num %}
+                {% if page_num == retrospects.page %}
+                    <a href="{{ url_for('retrospect.retrospect_view', project_id=project.project_id, page=page_num) }}" class="active">{{ page_num }}</a>
+                {% else %}
+                    <a href="{{ url_for('retrospect.retrospect_view', project_id=project.project_id, page=page_num) }}">{{ page_num }}</a>
+                {% endif %}
+            {% else %}
+                <span>…</span>
+            {% endif %}
+        {% endfor %}
+        {% if retrospects.has_next %}
+            <a href="{{ url_for('retrospect.retrospect_view', project_id=project.project_id, page=retrospects.next_num) }}">다음 &gt;</a>
+        {% endif %}
+    </div>
+
+</body>
+</html>

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -16,12 +16,12 @@
         <li class="{% if request.path == '/sprint/sprint/<int:project_id>' %}active{% endif %}">
             <a href="{{ url_for('sprint.get_product_backlogs_view', project_id=project.project_id) }}"><img src="{{ url_for('static', filename='icons/sprint.svg') }}" alt="스프린트 아이콘" class="icon"> 스프린트</a>
         </li>
-        <!-- <li class="{% if request.path == '/board' %}active{% endif %}">
+        <li class="{% if request.path == '/board' %}active{% endif %}">
             <a href="{{ url_for('board') }}"><img src="{{ url_for('static', filename='icons/board.svg') }}" alt="보드 아이콘" class="icon"> 스크럼 보드</a>
+        </li> 
+        <li class="{% if request.path == '/retrospect/retrospect/<int:project_id>' %}active{% endif %}">
+            <a href="{{ url_for('retrospect.retrospect_view', project_id=project.project_id) }}"><img src="{{ url_for('static', filename='icons/review.svg') }}" alt="회고 아이콘" class="icon"> 스프린트 회고</a>
         </li>
-        <li class="{% if request.path == '/review' %}active{% endif %}">
-            <a href="{{ url_for('review') }}"><img src="{{ url_for('static', filename='icons/review.svg') }}" alt="회고 아이콘" class="icon"> 스프린트 회고</a>
-        </li> -->
     </ul>
 </div>
 <script>

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -19,7 +19,7 @@
         <li class="{% if request.path == '/board' %}active{% endif %}">
             <a href="{{ url_for('board') }}"><img src="{{ url_for('static', filename='icons/board.svg') }}" alt="보드 아이콘" class="icon"> 스크럼 보드</a>
         </li> 
-        <li class="{% if request.path == '/retrospect/retrospect/<int:project_id>' %}active{% endif %}">
+        <li class="{% if request.path == '/retrospect/<int:project_id>' %}active{% endif %}">
             <a href="{{ url_for('retrospect.retrospect_view', project_id=project.project_id) }}"><img src="{{ url_for('static', filename='icons/review.svg') }}" alt="회고 아이콘" class="icon"> 스프린트 회고</a>
         </li>
     </ul>

--- a/templates/view_retrospect_back.html
+++ b/templates/view_retrospect_back.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ retrospect.retrospect_title }}</title>
+</head>
+<body>
+    <h2>{{ retrospect.retrospect_title }}</h2>
+    <p><strong>작성자:</strong> {{ user_name }}</p>
+    <p><strong>스프린트:</strong>
+        {% if retrospect.sprint_id %}
+            {% for sprint in sprints %}
+                {% if sprint.sprint_id == retrospect.sprint_id %}
+                    {{ sprint.sprint_name }}
+                {% endif %}
+            {% endfor %}
+        {% else %}
+            None
+        {% endif %}
+    </p>
+    <p><strong>카테고리:</strong> {{ retrospect.label }}</p>
+    
+
+    <hr>
+
+    <h3>내용</h3>
+    <p>{{ retrospect.retrospect_content }}</p>
+
+    <hr>
+
+    <button onclick="location.href='{{ url_for('retrospect.retrospect_view', project_id=retrospect.project_id) }}'">목록으로 돌아가기</button>
+</body>
+</html>

--- a/views/retrospect_view.py
+++ b/views/retrospect_view.py
@@ -1,0 +1,111 @@
+# retrospect_view.py
+
+from flask import Blueprint, render_template, request, redirect, url_for, flash, jsonify
+from models.project_model import Project, UserProject
+from models.sprint_model import Sprint
+from models.user_model import Users
+from models.retrospect_model import Retrospect
+from controllers.retrospect_controller import get_sprints, create_retrospect, update_retrospect, delete_retrospect, get_retrospect_by_id, get_user_name_by_project_and_user
+from flask_login import current_user, login_required
+from database import db
+
+# Blueprint 객체 생성
+retrospect_bp = Blueprint('retrospect', __name__)
+
+# retrospect 관리 페이지
+@retrospect_bp.route('/retrospect/<int:project_id>', methods=['GET'])
+@login_required
+def retrospect_view(project_id):
+    project = Project.query.get_or_404(project_id)
+    sprints = get_sprints(project_id)
+    label = request.args.get('label', 'all')
+    sprint_id = request.args.get('sprint', 'all')
+
+    query = Retrospect.query.filter_by(project_id=project_id)
+    if label != 'all':
+        query = query.filter_by(label=label)
+    if sprint_id != 'all':
+        query = query.filter_by(sprint_id=sprint_id)
+
+    retrospects = query.order_by(Retrospect.retrospect_id.desc()).paginate(page=request.args.get('page', 1, type=int), per_page=12)
+
+    user_projects = UserProject.query.filter_by(project_id=project_id).all()
+    user_map = {user_project.user_id: user_project.user_name for user_project in user_projects}    
+
+    return render_template('retrospect_back.html', project=project, project_id=project_id, sprints=sprints, retrospects=retrospects, user_map=user_map)
+
+# 회고 생성 페이지
+@retrospect_bp.route('/retrospect/<int:project_id>/create', methods=['GET'])
+@login_required
+def get_create_retrospect_view(project_id):
+    project = Project.query.get_or_404(project_id)
+    sprints = get_sprints(project_id)
+    return render_template('create_retrospect_back.html', project=project, sprints=sprints)
+
+# 회고 생성
+@retrospect_bp.route('/retrospect/<int:project_id>/create', methods=['POST'])
+@login_required
+def create_retrospect_view(project_id):
+    data = {
+        "user_id": current_user.id,
+        "project_id": project_id,
+        "sprint_id": request.form.get("sprint_id"),
+        "retrospect_title": request.form.get("retrospect_title"),
+        "retrospect_content": request.form.get("retrospect_content"),
+        "label": request.form.get("label")
+    }
+    if create_retrospect(data):
+        flash("회고가 성공적으로 생성되었습니다.", "success")
+    else:
+        flash("회고 생성에 실패했습니다.", "error")
+    return redirect(url_for('retrospect.retrospect_view', project_id=project_id))
+
+# 회고 수정 페이지
+@retrospect_bp.route('/retrospect/<int:project_id>/edit/<int:retrospect_id>', methods=['GET'])
+@login_required
+def get_edit_retrospect_view(project_id, retrospect_id):
+    project = Project.query.get_or_404(project_id)
+    retrospect = Retrospect.query.get_or_404(retrospect_id)
+    sprints = get_sprints(project_id)
+    return render_template('create_retrospect_back.html', project=project, retrospect=retrospect, sprints=sprints)
+
+# 회고 수정
+@retrospect_bp.route('/retrospect/<int:project_id>/edit/<int:retrospect_id>', methods=["POST"])
+@login_required
+def edit_retrospect_view(project_id, retrospect_id):
+    data = {
+        "retrospect_title": request.form.get("retrospect_title"),
+        "retrospect_content": request.form.get("retrospect_content"),
+        "label": request.form.get("label"),
+        "sprint_id": request.form.get("sprint_id")
+    }
+    if update_retrospect(retrospect_id, data):
+        flash("회고가 성공적으로 수정되었습니다.", "success")
+    else:
+        flash("회고 수정에 실패했습니다.", "error")
+    return redirect(url_for('retrospect.retrospect_view', project_id=project_id))
+
+# 회고 조회 페이지
+@retrospect_bp.route('/retrospect/<int:project_id>/view/<int:retrospect_id>', methods=["GET"])
+@login_required
+def view_retrospect_view(project_id, retrospect_id):
+    retrospect = get_retrospect_by_id(retrospect_id)
+    if not retrospect:
+        return render_template("404.html"), 404
+    
+    sprints = get_sprints(project_id)
+
+    user_name = get_user_name_by_project_and_user(project_id, retrospect.user_id)
+
+    return render_template('view_retrospect_back.html', retrospect=retrospect, sprints=sprints, user_name=user_name)
+
+# 회고 삭제
+@retrospect_bp.route('/retrospect/<int:project_id>/delete/<int:retrospect_id>', methods=["POST"])
+@login_required
+def delete_retrospect_view(project_id, retrospect_id):
+    if delete_retrospect(retrospect_id):
+        flash("회고가 성공적으로 삭제되었습니다.", "success")
+    else:
+        flash("회고 삭제에 실패했습니다.", "error")
+    return redirect(url_for('retrospect.retrospect_view', project_id=project_id))
+

--- a/views/retrospect_view.py
+++ b/views/retrospect_view.py
@@ -13,7 +13,7 @@ from database import db
 retrospect_bp = Blueprint('retrospect', __name__)
 
 # retrospect 관리 페이지
-@retrospect_bp.route('/retrospect/<int:project_id>', methods=['GET'])
+@retrospect_bp.route('/<int:project_id>', methods=['GET'])
 @login_required
 def retrospect_view(project_id):
     project = Project.query.get_or_404(project_id)
@@ -35,7 +35,7 @@ def retrospect_view(project_id):
     return render_template('retrospect_back.html', project=project, project_id=project_id, sprints=sprints, retrospects=retrospects, user_map=user_map)
 
 # 회고 생성 페이지
-@retrospect_bp.route('/retrospect/<int:project_id>/create', methods=['GET'])
+@retrospect_bp.route('/<int:project_id>/create', methods=['GET'])
 @login_required
 def get_create_retrospect_view(project_id):
     project = Project.query.get_or_404(project_id)
@@ -43,7 +43,7 @@ def get_create_retrospect_view(project_id):
     return render_template('create_retrospect_back.html', project=project, sprints=sprints)
 
 # 회고 생성
-@retrospect_bp.route('/retrospect/<int:project_id>/create', methods=['POST'])
+@retrospect_bp.route('/<int:project_id>/create', methods=['POST'])
 @login_required
 def create_retrospect_view(project_id):
     data = {
@@ -61,7 +61,7 @@ def create_retrospect_view(project_id):
     return redirect(url_for('retrospect.retrospect_view', project_id=project_id))
 
 # 회고 수정 페이지
-@retrospect_bp.route('/retrospect/<int:project_id>/edit/<int:retrospect_id>', methods=['GET'])
+@retrospect_bp.route('/<int:project_id>/edit/<int:retrospect_id>', methods=['GET'])
 @login_required
 def get_edit_retrospect_view(project_id, retrospect_id):
     project = Project.query.get_or_404(project_id)
@@ -70,7 +70,7 @@ def get_edit_retrospect_view(project_id, retrospect_id):
     return render_template('create_retrospect_back.html', project=project, retrospect=retrospect, sprints=sprints)
 
 # 회고 수정
-@retrospect_bp.route('/retrospect/<int:project_id>/edit/<int:retrospect_id>', methods=["POST"])
+@retrospect_bp.route('/<int:project_id>/edit/<int:retrospect_id>', methods=["POST"])
 @login_required
 def edit_retrospect_view(project_id, retrospect_id):
     data = {
@@ -86,7 +86,7 @@ def edit_retrospect_view(project_id, retrospect_id):
     return redirect(url_for('retrospect.retrospect_view', project_id=project_id))
 
 # 회고 조회 페이지
-@retrospect_bp.route('/retrospect/<int:project_id>/view/<int:retrospect_id>', methods=["GET"])
+@retrospect_bp.route('/<int:project_id>/view/<int:retrospect_id>', methods=["GET"])
 @login_required
 def view_retrospect_view(project_id, retrospect_id):
     retrospect = get_retrospect_by_id(retrospect_id)
@@ -100,7 +100,7 @@ def view_retrospect_view(project_id, retrospect_id):
     return render_template('view_retrospect_back.html', retrospect=retrospect, sprints=sprints, user_name=user_name)
 
 # 회고 삭제
-@retrospect_bp.route('/retrospect/<int:project_id>/delete/<int:retrospect_id>', methods=["POST"])
+@retrospect_bp.route('/<int:project_id>/delete/<int:retrospect_id>', methods=["POST"])
 @login_required
 def delete_retrospect_view(project_id, retrospect_id):
     if delete_retrospect(retrospect_id):


### PR DESCRIPTION
## #️⃣연관된 이슈

> #90 

## 📝작업 내용

> 스프린트 회고를 생성, 수정, 조회, 삭제하는 로직을 구현했습니다.
회고, 리스크 카테고리 구별을 위해 DB에 label 컬럼을 추가했습니다.
(파일 첨부 및 저장 로직은 추후 구현할 예정)

### 스크린샷 
스프린트 회고 목록
<img width="1463" alt="스크린샷 2024-11-20 오후 2 00 32" src="https://github.com/user-attachments/assets/ad3cad7f-49ae-45e2-9645-3096773fd494">

스프린트 회고 작성 및 수정
<img width="1468" alt="스크린샷 2024-11-20 오후 2 01 49" src="https://github.com/user-attachments/assets/7ff3ba08-136f-48b1-8917-e1d370536834">

스프린트 회고 조회
<img width="1468" alt="스크린샷 2024-11-20 오후 2 02 27" src="https://github.com/user-attachments/assets/de62d213-a764-43f0-b5bb-d794d9fb47b3">
