### PR TITLE
feat issue #90: 스프린트 회고 작성 시 파일 첨부 로직 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ views/__pycache__
 *.DS_Store
 # 유저스토리 테이블에 테스트용 데이터 생성하는 파일 무시
 add_test_data.py
+
+google_drive_key.json

--- a/controllers/productbacklog_controller.py
+++ b/controllers/productbacklog_controller.py
@@ -6,138 +6,115 @@ from database import db
 
 # 특정 프로젝트의 유저스토리 목록을 가져오는 함수
 def get_user_stories(project_id):
-    try:
-        user_stories = UserStory.query.filter_by(project_id=project_id).order_by(UserStory.story_id).all()
-        return user_stories if user_stories else []
-    except Exception:
-        return None
+    user_stories = UserStory.query.filter_by(project_id=project_id).order_by(UserStory.story_id).all()
+    return user_stories if user_stories else []
 
 # 유저스토리를 지정된 프로덕트 백로그에 추가하는 함수
 def update_product_backlog(story_id, backlog_id):
-    try:
-        user_story = UserStory.query.get(story_id)
-        if user_story:
-            user_story.product_backlog_id = backlog_id
-            db.session.commit()
-            return True
-        else:
-            return False
-    except Exception:
-        db.session.rollback()
+    user_story = UserStory.query.get(story_id)
+    if user_story:
+        user_story.product_backlog_id = backlog_id
+        db.session.commit()
+        return True
+    else:
         return False
 
 # 새로운 ProductBacklog 그룹을 생성하거나 기존 백로그 그룹을 업데이트하고, 유저스토리들을 해당 그룹으로 업데이트하는 함수
 def create_or_update_product_backlog_group(group_name, story_ids, backlog_id=None):
-    try:
-        if backlog_id:
-            # 기존 백로그가 있는 경우 이름 업데이트
-            existing_backlog = ProductBacklog.query.get(backlog_id)
-            if existing_backlog:
-                existing_backlog.product_backlog_content = group_name
-                db.session.add(existing_backlog)
-                db.session.commit()
+    if backlog_id:
+        # 기존 백로그가 있는 경우 이름 업데이트
+        existing_backlog = ProductBacklog.query.get(backlog_id)
+        if existing_backlog:
+            existing_backlog.product_backlog_content = group_name
+            db.session.add(existing_backlog)
+            db.session.commit()
 
-                # 유저스토리의 product_backlog_id를 기존 백로그 ID로 업데이트
-                for story_id in story_ids:
-                    user_story = UserStory.query.get(story_id)
-                    if user_story:
-                        user_story.product_backlog_id = existing_backlog.product_backlog_id
-                db.session.commit()
-                return existing_backlog.product_backlog_id
+            # 유저스토리의 product_backlog_id를 기존 백로그 ID로 업데이트
+            for story_id in story_ids:
+                user_story = UserStory.query.get(story_id)
+                if user_story:
+                    user_story.product_backlog_id = existing_backlog.product_backlog_id
+            db.session.commit()
+            return existing_backlog.product_backlog_id
         
-        # 새로운 백로그 생성
-        first_story = UserStory.query.get(story_ids[0])
-        if not first_story:
-            return None
-        project_id = first_story.project_id
-        new_backlog_order = ProductBacklog.query.filter_by(project_id=project_id).count() + 1
-        new_backlog = ProductBacklog(
-            story_id=first_story.story_id,  # 첫 번째 story_id 임시 설정 (필수 항목 채우기 위해)
-            project_id=project_id,
-            product_backlog_content=group_name,
-            backlog_order=new_backlog_order
-        )
-        db.session.add(new_backlog)
-        db.session.commit()
-
-        # 유저스토리의 product_backlog_id를 새로운 백로그 ID로 업데이트
-        for story_id in story_ids:
-            user_story = UserStory.query.get(story_id)
-            if user_story:
-                user_story.product_backlog_id = new_backlog.product_backlog_id
-        db.session.commit()
-        
-        return new_backlog.product_backlog_id
-    except Exception:
-        db.session.rollback()
+    # 새로운 백로그 생성
+    first_story = UserStory.query.get(story_ids[0])
+    if not first_story:
         return None
+    project_id = first_story.project_id
+    new_backlog_order = ProductBacklog.query.filter_by(project_id=project_id).count() + 1
+    new_backlog = ProductBacklog(
+        story_id=first_story.story_id,  # 첫 번째 story_id 임시 설정 (필수 항목 채우기 위해)
+        project_id=project_id,
+        product_backlog_content=group_name,
+        backlog_order=new_backlog_order
+    )
+    db.session.add(new_backlog)
+    db.session.commit()
+
+    # 유저스토리의 product_backlog_id를 새로운 백로그 ID로 업데이트
+    for story_id in story_ids:
+        user_story = UserStory.query.get(story_id)
+        if user_story:
+            user_story.product_backlog_id = new_backlog.product_backlog_id
+    db.session.commit()
     
+    return new_backlog.product_backlog_id
+
 # 전달된 모든 백로그 그룹 데이터를 저장하는 함수       
 def save_all_backlog_groups(backlog_groups, unassigned_story_ids):
-    try:
-        success = True
-        processed_backlog_ids = set()
-        for group in backlog_groups:
-            group_name = group['backlogName']
-            story_ids = group['storyIds']
-            backlog_id = group.get('backlogId')
+    success = True
+    processed_backlog_ids = set()
+    for group in backlog_groups:
+        group_name = group['backlogName']
+        story_ids = group['storyIds']
+        backlog_id = group.get('backlogId')
 
-            # 백로그 그룹 생성 또는 업데이트
-            updated_backlog_id = create_or_update_product_backlog_group(group_name, story_ids, backlog_id)
-            if updated_backlog_id is None:
-                success = False
-            else:
-                processed_backlog_ids.add(updated_backlog_id)
+        # 백로그 그룹 생성 또는 업데이트
+        updated_backlog_id = create_or_update_product_backlog_group(group_name, story_ids, backlog_id)
+        if updated_backlog_id is None:
+            success = False
+        else:
+            processed_backlog_ids.add(updated_backlog_id)
 
-        # 백로그에 속하지 않는 유저 스토리의 product_backlog_id를 None으로 업데이트
-        for story_id in unassigned_story_ids:
-            user_story = UserStory.query.get(story_id)
-            if user_story:
-                user_story.product_backlog_id = None
-                db.session.add(user_story)
-        db.session.commit()
+    # 백로그에 속하지 않는 유저 스토리의 product_backlog_id를 None으로 업데이트
+    for story_id in unassigned_story_ids:
+        user_story = UserStory.query.get(story_id)
+        if user_story:
+            user_story.product_backlog_id = None
+            db.session.add(user_story)
+    db.session.commit()
 
-        # 유저스토리가 없는 빈 백로그 삭제
-        empty_backlogs = ProductBacklog.query.filter(ProductBacklog.project_id == UserStory.query.get(unassigned_story_ids[0]).project_id if unassigned_story_ids else None).all()
-        for backlog in empty_backlogs:
-            if backlog.product_backlog_id not in processed_backlog_ids:
-                associated_stories = UserStory.query.filter_by(product_backlog_id=backlog.product_backlog_id).all()
-                if not associated_stories:
-                    db.session.delete(backlog)
-        db.session.commit()
-        
-        return success
-    except Exception:
-        db.session.rollback()
-        return False
+    # 유저스토리가 없는 빈 백로그 삭제
+    empty_backlogs = ProductBacklog.query.filter(ProductBacklog.project_id == UserStory.query.get(unassigned_story_ids[0]).project_id if unassigned_story_ids else None).all()
+    for backlog in empty_backlogs:
+        if backlog.product_backlog_id not in processed_backlog_ids:
+            associated_stories = UserStory.query.filter_by(product_backlog_id=backlog.product_backlog_id).all()
+            if not associated_stories:
+                db.session.delete(backlog)
+    db.session.commit()
+    return success
+
 
 # 백로그와 해당 백로그에 포함된 유저스토리의 참조를 삭제하는 함수
 def delete_product_backlog(backlog_id):
-    try:
-        backlog = ProductBacklog.query.get(backlog_id)
-        if backlog:
-            user_stories = UserStory.query.filter_by(product_backlog_id=backlog_id).all()
-            for story in user_stories:
-                story.product_backlog_id = None  # 초기화하여 유저스토리 박스로 이동하도록 설정
-                db.session.add(story)
-            
-            db.session.delete(backlog)  # 백로그 삭제
-            db.session.commit()
-            return True
-    except Exception:
-        db.session.rollback()
-        return False
-
-# 백로그 박스의 순서를 저장하는 함수
-def save_backlog_order(backlog_order_list):
-    try:
-        for order, backlog_id in enumerate(backlog_order_list, start=1):
-            backlog = ProductBacklog.query.get(backlog_id)
-            if backlog:
-                backlog.backlog_order = order
-                db.session.add(backlog)
+    backlog = ProductBacklog.query.get(backlog_id)
+    if backlog:
+        user_stories = UserStory.query.filter_by(product_backlog_id=backlog_id).all()
+        for story in user_stories:
+            story.product_backlog_id = None  # 초기화하여 유저스토리 박스로 이동하도록 설정
+            db.session.add(story)
+        
+        db.session.delete(backlog)  # 백로그 삭제
         db.session.commit()
         return True
-    except Exception:
-        db.session.rollback()
-        return False
+    
+# 백로그 박스의 순서를 저장하는 함수
+def save_backlog_order(backlog_order_list):
+    for order, backlog_id in enumerate(backlog_order_list, start=1):
+        backlog = ProductBacklog.query.get(backlog_id)
+        if backlog:
+            backlog.backlog_order = order
+            db.session.add(backlog)
+    db.session.commit()
+    return True

--- a/controllers/retrospect_controller.py
+++ b/controllers/retrospect_controller.py
@@ -4,6 +4,7 @@ from models.retrospect_model import Retrospect
 from models.project_model import UserProject
 from models.sprint_model import Sprint
 from database import db
+from drive.drive_init import upload_to_drive
 
 # 특정 프로젝트의 스프린트 목록을 가져오는 함수
 def get_sprints(project_id):
@@ -72,3 +73,11 @@ def get_filtered_retrospects(project_id, category=None, sprint_id=None, page=1, 
         query = query.filter_by(sprint_id=sprint_id)
 
     return query.order_by(Retrospect.retrospect_id.desc()).paginate(page=page, per_page=per_page, error_out=False)
+
+# 파일 업로드하고 링크 반환하는 함수
+def handle_file_upload(file):
+    if file and file.filename != '':
+        folder_id = "1FcmKeVM8SaYPcJ8CUfOt6iBkB6tseANk"
+        upload_result = upload_to_drive(file, file.filename, folder_id)
+        return upload_result.get('webViewLink')
+    return None

--- a/controllers/retrospect_controller.py
+++ b/controllers/retrospect_controller.py
@@ -7,11 +7,8 @@ from database import db
 
 # 특정 프로젝트의 스프린트 목록을 가져오는 함수
 def get_sprints(project_id):
-    try:
-        sprints = Sprint.query.filter_by(project_id=project_id).order_by(Sprint.sprint_id).all()
-        return sprints if sprints else []
-    except Exception:
-        return None
+    sprints = Sprint.query.filter_by(project_id=project_id).order_by(Sprint.sprint_id).all()
+    return sprints if sprints else []
 
 # 회고를 생성하고 저장하는 함수
 def create_retrospect(data):
@@ -21,8 +18,9 @@ def create_retrospect(data):
         sprint_id=data.get('sprint_id'),
         retrospect_title=data.get('retrospect_title'),
         retrospect_content=data.get('retrospect_content'),
-        label=data.get('label')
-    )
+        label=data.get('label'),
+        file_link=data.get('file_link'),
+    )  
     db.session.add(retrospect)
     db.session.commit()
     return True
@@ -35,6 +33,8 @@ def update_retrospect(retrospect_id, data):
     retrospect.retrospect_title = data.get("retrospect_title", retrospect.retrospect_title)
     retrospect.retrospect_content = data.get("retrospect_content", retrospect.retrospect_content)
     retrospect.label = data.get("label", retrospect.label)
+    retrospect.file_link = data.get("file_link", retrospect.file_link)
+    retrospect.sprint_id = data.get("sprint_id", retrospect.sprint_id)
     db.session.commit()
     return True
 

--- a/controllers/retrospect_controller.py
+++ b/controllers/retrospect_controller.py
@@ -65,13 +65,10 @@ def delete_retrospect(retrospect_id):
 # 회고를 필터링하는 함수
 def get_filtered_retrospects(project_id, category=None, sprint_id=None, page=1, per_page=12):
     query = Retrospect.query.filter_by(project_id=project_id)
-
     if category and category != 'all':
         query = query.filter_by(label=category)
-    
     if sprint_id and sprint_id != 'all':
         query = query.filter_by(sprint_id=sprint_id)
-
     return query.order_by(Retrospect.retrospect_id.desc()).paginate(page=page, per_page=per_page, error_out=False)
 
 # 파일 업로드하고 링크 반환하는 함수

--- a/drive/drive_init.py
+++ b/drive/drive_init.py
@@ -9,7 +9,6 @@ def init_drive_api():
     service_account_file = os.environ.get('GOOGLE_DRIVE_KEY_PATH')
     if not service_account_file:
         raise ValueError("환경변수 GOOGLE_DRIVE_KEY_PATH가 설정되지 않았습니다.")
-    
     scopes = ["https://www.googleapis.com/auth/drive"]
     credentials = Credentials.from_service_account_file(service_account_file, scopes=scopes)
 
@@ -19,25 +18,21 @@ def init_drive_api():
 # 파일 업로드 함수
 def upload_to_drive(file, file_name, folder_id):
     drive_service = init_drive_api()
-
     # 임시 파일에 업로드된 파일을 저장
     with tempfile.NamedTemporaryFile(delete=False) as temp_file:
         temp_file.write(file.read())
         temp_file_path = temp_file.name
-
     try:
         media = MediaFileUpload(temp_file_path, mimetype=file.content_type, resumable=True)
         file_metadata = {
             "name": file_name,
             "parents": [folder_id]
         }
-
         uploaded_file = drive_service.files().create(
             body=file_metadata,
             media_body=media,
             fields="id, webViewLink"
         ).execute()
-
         return {
             "id": uploaded_file.get("id"),
             "webViewLink": uploaded_file.get("webViewLink")
@@ -45,27 +40,3 @@ def upload_to_drive(file, file_name, folder_id):
     finally:
         # 임시 파일 삭제
         os.remove(temp_file_path)
-
-# def upload_to_drive(file_path, file_name, folder_id):
-#     drive_service = init_drive_api()
-#     file_metadata = {'name': file_name, 'parents': [folder_id]}
-    
-#     media = MediaFileUpload(file_path, resumable=True)
-#     uploaded_file = drive_service.files().create(
-#         body=file_metadata,
-#         media_body=media,
-#         fields='id, webViewLink'
-#     ).execute()
-
-#     return {
-#         'file_id': uploaded_file.get('id'),
-#         'view_link': uploaded_file.get('webViewLink')
-#     }
-
-# if __name__ == "__main__":
-#     file_path = "README.md"
-#     file_name = "README.md"
-#     folder_id = "1FcmKeVM8SaYPcJ8CUfOt6iBkB6tseANk"
-
-#     upload_result = upload_to_drive(file_path, file_name, folder_id)
-#     print(f"file uploaded successfully: {upload_result['view_link']}")

--- a/drive/drive_init.py
+++ b/drive/drive_init.py
@@ -1,0 +1,71 @@
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
+from google.oauth2.service_account import Credentials
+import os
+import tempfile
+
+# 구글 드라이브 API 초기화 함수
+def init_drive_api():
+    service_account_file = os.environ.get('GOOGLE_DRIVE_KEY_PATH')
+    if not service_account_file:
+        raise ValueError("환경변수 GOOGLE_DRIVE_KEY_PATH가 설정되지 않았습니다.")
+    
+    scopes = ["https://www.googleapis.com/auth/drive"]
+    credentials = Credentials.from_service_account_file(service_account_file, scopes=scopes)
+
+    drive_service = build('drive', 'v3', credentials=credentials)
+    return drive_service
+
+# 파일 업로드 함수
+def upload_to_drive(file, file_name, folder_id):
+    drive_service = init_drive_api()
+
+    # 임시 파일에 업로드된 파일을 저장
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        temp_file.write(file.read())
+        temp_file_path = temp_file.name
+
+    try:
+        media = MediaFileUpload(temp_file_path, mimetype=file.content_type, resumable=True)
+        file_metadata = {
+            "name": file_name,
+            "parents": [folder_id]
+        }
+
+        uploaded_file = drive_service.files().create(
+            body=file_metadata,
+            media_body=media,
+            fields="id, webViewLink"
+        ).execute()
+
+        return {
+            "id": uploaded_file.get("id"),
+            "webViewLink": uploaded_file.get("webViewLink")
+        }
+    finally:
+        # 임시 파일 삭제
+        os.remove(temp_file_path)
+
+# def upload_to_drive(file_path, file_name, folder_id):
+#     drive_service = init_drive_api()
+#     file_metadata = {'name': file_name, 'parents': [folder_id]}
+    
+#     media = MediaFileUpload(file_path, resumable=True)
+#     uploaded_file = drive_service.files().create(
+#         body=file_metadata,
+#         media_body=media,
+#         fields='id, webViewLink'
+#     ).execute()
+
+#     return {
+#         'file_id': uploaded_file.get('id'),
+#         'view_link': uploaded_file.get('webViewLink')
+#     }
+
+# if __name__ == "__main__":
+#     file_path = "README.md"
+#     file_name = "README.md"
+#     folder_id = "1FcmKeVM8SaYPcJ8CUfOt6iBkB6tseANk"
+
+#     upload_result = upload_to_drive(file_path, file_name, folder_id)
+#     print(f"file uploaded successfully: {upload_result['view_link']}")

--- a/models/retrospect_model.py
+++ b/models/retrospect_model.py
@@ -11,14 +11,16 @@ class Retrospect(db.Model):
     retrospect_title = db.Column(db.String(50), nullable=True)
     retrospect_content = db.Column(db.Text, nullable=True)
     label = db.Column(db.String(10), nullable=True)
+    file_link = db.Column(db.String(2083), nullable=True)
 
-    def __init__(self, user_id, project_id, sprint_id, retrospect_title=None, retrospect_content=None, label=None):
+    def __init__(self, user_id, project_id, sprint_id, retrospect_title=None, retrospect_content=None, label=None, file_link=None):
         self.user_id = user_id
         self.project_id = project_id
         self.sprint_id = sprint_id
         self.retrospect_title = retrospect_title
         self.retrospect_content = retrospect_content
         self.label = label
+        self.file_link = file_link
 
     def save_to_db(self):
         db.session.add(self)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ requests==2.32.3
 oauthlib==3.2.2
 flask-sqlalchemy==3.1.1
 mysqlclient==2.2.5
+google-api-python-client 
+google-auth
+google-auth-oauthlib
+google-auth-httplib2

--- a/static/js/retrospect.js
+++ b/static/js/retrospect.js
@@ -108,3 +108,13 @@ function showMessageModal(title, message) {
 function closeMessageModal() {
     document.getElementById("messageModal").classList.add("hidden");
 }
+
+// 파일 선택 시 호출
+function handleFileSelect(input) {
+    if (input.files.length > 0) {
+        const fileName = input.files[0].name;
+        document.querySelector('.file-upload-input').value = fileName;
+    } else {
+        document.querySelector('.file-upload-input').value = '';
+    }
+}

--- a/templates/create_retrospect.html
+++ b/templates/create_retrospect.html
@@ -17,6 +17,7 @@
             <h2 class="page-title">회고 작성하기</h2>
             <form 
                 method="POST"
+                enctype="multipart/form-data"
                 class="retrospect-form"
                 action="{{ retrospect and url_for('retrospect.edit_retrospect_view', project_id=project.project_id, retrospect_id=retrospect.retrospect_id) or url_for('retrospect.create_retrospect_view', project_id=project.project_id) }}"
             >
@@ -80,13 +81,22 @@
                 <div class="form-group">
                     <label for="file" class="form-label">파일 첨부</label>
                     <div class="file-upload-container">
+                        <input
+                            type="file"
+                            id="file"
+                            name="file"
+                            class="file-upload-hidden"
+                            style="display: none;"
+                            onchange="handleFileSelect(this)"
+                        />
                         <input 
                             type="text" 
                             class="file-upload-input" 
                             placeholder="버튼을 클릭해 첨부파일을 업로드 해주세요" 
+                            value="{{ retrospect.file_link if retrospect and retrospect.file_link else '' }}"
                             readonly
                         />
-                        <button type="button" class="file-upload-btn">파일 업로드</button>
+                        <button type="button" class="file-upload-btn" onclick="document.getElementById('file').click()">파일 업로드</button>
                     </div>
                 </div>
 
@@ -105,4 +115,5 @@
         </div>
     </div>
 </body>
+<script src="{{ url_for('static', filename='js/retrospect.js') }}"></script>
 </html>

--- a/templates/view_retrospect.html
+++ b/templates/view_retrospect.html
@@ -54,6 +54,14 @@
                     <strong>카테고리:</strong>
                     {{ '회고' if retrospect.label == 'retrospect' else '리스크' }}
                 </div>
+                <div class="retrospect-file">
+                    <strong>첨부 파일:</strong>
+                    {% if file_link %}
+                        <a href="{{ file_link }}" target="_blank" download>파일 다운로드</a>
+                    {% else %}
+                        첨부된 파일이 없습니다.
+                    {% endif %}
+                </div>
             </div>
 
             <hr>
@@ -62,7 +70,6 @@
                 <h3>내용</h3>
                 <p>{{ retrospect.retrospect_content.replace('\n', '<br>')|safe }}</p>
             </div>
-
             <hr>
 
             <button class="btn-back" onclick="location.href='{{ url_for('retrospect.retrospect_view', project_id=retrospect.project_id) }}'">

--- a/templates/view_retrospect.html
+++ b/templates/view_retrospect.html
@@ -54,7 +54,7 @@
                     <strong>카테고리:</strong>
                     {{ '회고' if retrospect.label == 'retrospect' else '리스크' }}
                 </div>
-                <div class="retrospect-file">
+                <div class="retrospect-item">
                     <strong>첨부 파일:</strong>
                     {% if file_link %}
                         <a href="{{ file_link }}" target="_blank" download>파일 다운로드</a>

--- a/views/productbacklog_view.py
+++ b/views/productbacklog_view.py
@@ -1,9 +1,8 @@
 # productbacklog_view.py
 
-from flask import Blueprint, render_template, request, redirect, url_for, flash, jsonify
+from flask import Blueprint, render_template, request, jsonify
 from controllers.productbacklog_controller import get_user_stories, update_product_backlog, create_or_update_product_backlog_group, save_all_backlog_groups, delete_product_backlog, save_backlog_order
 from models.productbacklog_model import ProductBacklog
-from models.userstory_model import UserStory
 from models.project_model import Project, UserProject
 from flask_login import current_user
 from database import db

--- a/views/retrospect_view.py
+++ b/views/retrospect_view.py
@@ -6,6 +6,7 @@ from models.retrospect_model import Retrospect
 from controllers.retrospect_controller import get_sprints, create_retrospect, update_retrospect, delete_retrospect, get_retrospect_by_id, get_user_name_by_project_and_user, get_filtered_retrospects
 from flask_login import current_user, login_required
 from database import db
+from drive.drive_init import upload_to_drive
 
 # Blueprint 객체 생성
 retrospect_bp = Blueprint('retrospect', __name__)
@@ -45,13 +46,22 @@ def get_create_retrospect_view(project_id):
 @retrospect_bp.route('/<int:project_id>/create', methods=['POST'])
 @login_required
 def create_retrospect_view(project_id):
+    file = request.files.get('file')
+    if file and file.filename != '':
+        folder_id = "1FcmKeVM8SaYPcJ8CUfOt6iBkB6tseANk"
+        upload_result = upload_to_drive(file, file.filename, folder_id)
+        file_link = upload_result['webViewLink']
+    else:
+        file_link = None
+
     data = {
         "user_id": current_user.id,
         "project_id": project_id,
         "sprint_id": request.form.get("sprint_id"),
         "retrospect_title": request.form.get("retrospect_title"),
         "retrospect_content": request.form.get("retrospect_content"),
-        "label": request.form.get("label")
+        "label": request.form.get("label"),
+        "file_link": file_link
     }
     if create_retrospect(data):
         flash("회고가 성공적으로 생성되었습니다.", "success")
@@ -80,11 +90,20 @@ def edit_retrospect_view(project_id, retrospect_id):
         flash("본인이 작성한 글만 수정할 수 있습니다.", "error")
         return redirect(url_for('retrospect.retrospect_view', project_id=project_id))
     
+    file = request.files.get('file')
+    file_link = retrospect.file_link
+
+    if file and file.filename != '':
+        folder_id = "1FcmKeVM8SaYPcJ8CUfOt6iBkB6tseANk"
+        upload_result = upload_to_drive(file, file.filename, folder_id)
+        file_link = upload_result.get('webViewLink')  # 새 파일 링크로 업데이트
+
     data = {
         "retrospect_title": request.form.get("retrospect_title"),
         "retrospect_content": request.form.get("retrospect_content"),
         "label": request.form.get("label"),
-        "sprint_id": request.form.get("sprint_id")
+        "sprint_id": request.form.get("sprint_id"),
+        "file_link": file_link
     }
     if update_retrospect(retrospect_id, data):
         flash("회고가 성공적으로 수정되었습니다.", "success")
@@ -101,9 +120,9 @@ def view_retrospect_view(project_id, retrospect_id):
         return render_template("404.html"), 404
     project = Project.query.get_or_404(project_id)
     sprints = get_sprints(project_id)
-
     user_name = get_user_name_by_project_and_user(project_id, retrospect.user_id)
-    return render_template('view_retrospect.html', project=project, retrospect=retrospect, sprints=sprints, user_name=user_name,userproject=UserProject.find_by_user_and_project(current_user.id, project_id))
+    file_link = retrospect.file_link if retrospect.file_link else None
+    return render_template('view_retrospect.html', project=project, retrospect=retrospect, sprints=sprints, user_name=user_name, file_link=file_link, userproject=UserProject.find_by_user_and_project(current_user.id, project_id))
 
 # 회고 삭제
 @retrospect_bp.route('/<int:project_id>/delete/<int:retrospect_id>', methods=["POST"])

--- a/views/retrospect_view.py
+++ b/views/retrospect_view.py
@@ -1,9 +1,7 @@
 # retrospect_view.py
 
-from flask import Blueprint, render_template, request, redirect, url_for, flash, jsonify
+from flask import Blueprint, render_template, request, redirect, url_for, flash
 from models.project_model import Project, UserProject
-from models.sprint_model import Sprint
-from models.user_model import Users
 from models.retrospect_model import Retrospect
 from controllers.retrospect_controller import get_sprints, create_retrospect, update_retrospect, delete_retrospect, get_retrospect_by_id, get_user_name_by_project_and_user, get_filtered_retrospects
 from flask_login import current_user, login_required
@@ -33,7 +31,6 @@ def retrospect_view(project_id):
 
     user_projects = UserProject.query.filter_by(project_id=project_id).all()
     user_map = {user_project.user_id: user_project.user_name for user_project in user_projects}    
-    # 수정해야해요! userproject 부분
     return render_template('retrospect.html', project=project, project_id=project_id, sprints=sprints, retrospects=retrospects, user_map=user_map,userproject=UserProject.find_by_user_and_project(current_user.id, project_id))
 
 # 회고 생성 페이지
@@ -106,7 +103,6 @@ def view_retrospect_view(project_id, retrospect_id):
     sprints = get_sprints(project_id)
 
     user_name = get_user_name_by_project_and_user(project_id, retrospect.user_id)
-    # 수정해야해요! userproject 부분
     return render_template('view_retrospect.html', project=project, retrospect=retrospect, sprints=sprints, user_name=user_name,userproject=UserProject.find_by_user_and_project(current_user.id, project_id))
 
 # 회고 삭제

--- a/views/retrospect_view.py
+++ b/views/retrospect_view.py
@@ -3,7 +3,7 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash
 from models.project_model import Project, UserProject
 from models.retrospect_model import Retrospect
-from controllers.retrospect_controller import get_sprints, create_retrospect, update_retrospect, delete_retrospect, get_retrospect_by_id, get_user_name_by_project_and_user, get_filtered_retrospects
+from controllers.retrospect_controller import get_sprints, create_retrospect, update_retrospect, delete_retrospect, get_retrospect_by_id, get_user_name_by_project_and_user, get_filtered_retrospects, handle_file_upload
 from flask_login import current_user, login_required
 from database import db
 from drive.drive_init import upload_to_drive
@@ -47,12 +47,7 @@ def get_create_retrospect_view(project_id):
 @login_required
 def create_retrospect_view(project_id):
     file = request.files.get('file')
-    if file and file.filename != '':
-        folder_id = "1FcmKeVM8SaYPcJ8CUfOt6iBkB6tseANk"
-        upload_result = upload_to_drive(file, file.filename, folder_id)
-        file_link = upload_result['webViewLink']
-    else:
-        file_link = None
+    file_link = handle_file_upload(file)
 
     data = {
         "user_id": current_user.id,
@@ -91,12 +86,7 @@ def edit_retrospect_view(project_id, retrospect_id):
         return redirect(url_for('retrospect.retrospect_view', project_id=project_id))
     
     file = request.files.get('file')
-    file_link = retrospect.file_link
-
-    if file and file.filename != '':
-        folder_id = "1FcmKeVM8SaYPcJ8CUfOt6iBkB6tseANk"
-        upload_result = upload_to_drive(file, file.filename, folder_id)
-        file_link = upload_result.get('webViewLink')  # 새 파일 링크로 업데이트
+    file_link = handle_file_upload(file) or retrospect.file_link
 
     data = {
         "retrospect_title": request.form.get("retrospect_title"),


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #90, #98, #102 

## 📝작업 내용

>  스프린트 회고 작성 시 파일을 첨부하는 로직을 추가했습니다.
첨부한 파일을 저장하기 위해 Google Drive 서비스 계정을 생성하고, Google Drive API를 사용해 연동했습니다. 
Retrospect 테이블에 파일의 url 값을 저장하고 불러올 수 있도록 file_link 컬럼을 생성했습니다.

### 스크린샷 
파일 업로드 버튼 눌러서 파일을 선택하고 첨부한 화면
<img width="1470" alt="스크린샷 2024-11-23 오전 2 58 18" src="https://github.com/user-attachments/assets/1780b6d5-5346-463d-b105-a421e4dd5acd">
파일 다운로드를 클릭하면 구글 드라이브에 저장된 파일 링크로 이동
<img width="1470" alt="스크린샷 2024-11-23 오전 2 58 56" src="https://github.com/user-attachments/assets/8485631f-cf00-44ae-8420-9108b09081f4">
<img width="1470" alt="스크린샷 2024-11-23 오전 3 01 07" src="https://github.com/user-attachments/assets/0363ade8-79ba-456e-aa2c-646c157693e8">

## 💬리뷰 요구사항

> 실행 전 requirements.txt 확인하고 라이브러리 설치해주세요!!
구글 드라이브 API 연동을 위해서 노션의 .env 파일 수정사항을 확인하고 각자 파일에 반영해 주세요
서비스 계정 API 키 json 파일도 노션에 올렸습니다. drive 디렉토리 내에 생성해주세요.
