### PR TITLE
feat issue #90: 회고 파일 첨부 에러 해결, 파일 삭제 로직 추가 구현

### DIFF
--- a/controllers/retrospect_controller.py
+++ b/controllers/retrospect_controller.py
@@ -5,6 +5,7 @@ from models.project_model import UserProject
 from models.sprint_model import Sprint
 from database import db
 from drive.drive_init import upload_to_drive
+import os
 
 # 특정 프로젝트의 스프린트 목록을 가져오는 함수
 def get_sprints(project_id):
@@ -74,7 +75,9 @@ def get_filtered_retrospects(project_id, category=None, sprint_id=None, page=1, 
 # 파일 업로드하고 링크 반환하는 함수
 def handle_file_upload(file):
     if file and file.filename != '':
-        folder_id = "1FcmKeVM8SaYPcJ8CUfOt6iBkB6tseANk"
+        folder_id = os.getenv("GOOGLE_DRIVE_FOLDER_ID")
+        if not folder_id:
+            raise ValueError("환경변수 GOOGLE_DRIVE_FORDER_ID가 설정되지 않았습니다.")
         upload_result = upload_to_drive(file, file.filename, folder_id)
-        return upload_result.get('webContentLink')
+        return upload_result.get('webViewLink')
     return None

--- a/controllers/retrospect_controller.py
+++ b/controllers/retrospect_controller.py
@@ -4,7 +4,7 @@ from models.retrospect_model import Retrospect
 from models.project_model import UserProject
 from models.sprint_model import Sprint
 from database import db
-from drive.drive_init import upload_to_drive
+from drive.drive_init import upload_to_drive, delete_file_from_drive
 import os
 
 # 특정 프로젝트의 스프린트 목록을 가져오는 함수
@@ -59,6 +59,10 @@ def delete_retrospect(retrospect_id):
     retrospect = Retrospect.query.get(retrospect_id)
     if not retrospect:
         return False
+    if retrospect.file_link:
+        file_id = retrospect.file_link.split("/")[5]
+        if not delete_file_from_drive(file_id):
+            print(f"드라이브에서 파일 삭제 실패, file_id: {file_id}")
     db.session.delete(retrospect)
     db.session.commit()
     return True

--- a/drive/drive_init.py
+++ b/drive/drive_init.py
@@ -18,11 +18,15 @@ def init_drive_api():
 # 파일 업로드 함수
 def upload_to_drive(file, file_name, folder_id):
     drive_service = init_drive_api()
-    # 임시 파일에 업로드된 파일을 저장
-    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-        temp_file.write(file.read())
-        temp_file_path = temp_file.name
+     # 임시 파일에 업로드된 파일을 저장
+    temp_file_path = None
     try:
+        # 임시 파일 생성 및 저장
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(file.read())
+            temp_file_path = temp_file.name
+
+        # MediaFileUpload로 업로드
         media = MediaFileUpload(temp_file_path, mimetype=file.content_type, resumable=True)
         file_metadata = {
             "name": file_name,
@@ -31,12 +35,28 @@ def upload_to_drive(file, file_name, folder_id):
         uploaded_file = drive_service.files().create(
             body=file_metadata,
             media_body=media,
-            fields="id, webContentLink"
+            fields="id, webViewLink"
         ).execute()
+
+        # 파일 권한 설정
+        permission = {
+            "type": "anyone",
+            "role": "reader"
+        }
+        drive_service.permissions().create(
+            fileId=uploaded_file.get("id"),
+            body=permission
+        ).execute()
+        
         return {
             "id": uploaded_file.get("id"),
-            "webContentLink": uploaded_file.get("webContentLink")
+            "webViewLink": uploaded_file.get("webViewLink")
         }
+
     finally:
         # 임시 파일 삭제
-        os.remove(temp_file_path)
+        if temp_file_path and os.path.exists(temp_file_path):
+            try:
+                os.remove(temp_file_path)
+            except PermissionError:
+                print(f"파일 삭제 실패: {temp_file_path}. 다른 프로세스에서 사용 중일 수 있습니다.")

--- a/drive/drive_init.py
+++ b/drive/drive_init.py
@@ -60,3 +60,9 @@ def upload_to_drive(file, file_name, folder_id):
                 os.remove(temp_file_path)
             except PermissionError:
                 print(f"파일 삭제 실패: {temp_file_path}. 다른 프로세스에서 사용 중일 수 있습니다.")
+
+# 파일 삭제 함수
+def delete_file_from_drive(file_id):
+    drive_service = init_drive_api()
+    drive_service.files().delete(fileId=file_id).execute()
+    return True

--- a/views/retrospect_view.py
+++ b/views/retrospect_view.py
@@ -94,6 +94,9 @@ def edit_retrospect_view(project_id, retrospect_id):
 @login_required
 def view_retrospect_view(project_id, retrospect_id):
     retrospect = get_retrospect_by_id(retrospect_id)
+    print(f"retrieved retrospect: {retrospect}")
+    print(f"file link from retrospect: {retrospect.file_link}")
+    
     project = Project.query.get_or_404(project_id)
     sprints = get_sprints(project_id)
     user_name = get_user_name_by_project_and_user(project_id, retrospect.user_id)


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #90, #107, #108 

## 📝작업 내용

> 윈도우 os에서 파일 첨부 시 발생하는 에러를 해결했습니다.
드라이브 폴더 id를 .env 파일에 저장해서 관리하도록 변경했습니다.
회고 삭제 시 첨부된 파일도 드라이브 내에서 함께 삭제되도록 하는 로직을 구현했습니다.

## 💬리뷰 요구사항

> 노션 .env 파일 변경사항 확인해주세요!! 
